### PR TITLE
Refactor transformer modules

### DIFF
--- a/src/classical_transformer.py
+++ b/src/classical_transformer.py
@@ -1,0 +1,12 @@
+import torch.nn as nn
+
+from .transformer_classifier import TransformerClassifier
+
+
+class ClassicalTransformer(TransformerClassifier):
+    """Transformer classifier with classical components."""
+
+    def __init__(self, vocab_size: int, embedding_dim: int, num_classes: int) -> None:
+        embedding = nn.Embedding(vocab_size, embedding_dim)
+        attention = nn.MultiheadAttention(embedding_dim, num_heads=1)
+        super().__init__(embedding, attention, embedding_dim, num_classes)

--- a/src/hybrid_transformer.py
+++ b/src/hybrid_transformer.py
@@ -1,57 +1,8 @@
-import torch
 import torch.nn as nn
 
-from src.quantum_embedding import OptimizedQuantumEmbedding
-from src.quantum_attention import HybridMultiHeadAttention
-
-
-class TransformerClassifier(nn.Module):
-    """Simple transformer-based text classifier.
-
-    Parameters
-    ----------
-    embedding_layer : nn.Module
-        Either ``nn.Embedding`` or ``OptimizedQuantumEmbedding``.
-    attention_layer : nn.Module
-        Attention module compatible with ``nn.MultiheadAttention`` interface.
-    embedding_dim : int
-        Dimension of embeddings.
-    num_classes : int
-        Number of output classes.
-    """
-
-    def __init__(self, embedding_layer: nn.Module, attention_layer: nn.Module,
-                 embedding_dim: int, num_classes: int) -> None:
-        super().__init__()
-        self.embedding = embedding_layer
-        self.attention = attention_layer
-        self.ffn = nn.Sequential(
-            nn.Linear(embedding_dim, embedding_dim),
-            nn.ReLU(),
-            nn.Linear(embedding_dim, embedding_dim)
-        )
-        self.classifier = nn.Linear(embedding_dim, num_classes)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass."""
-        # x: (batch, seq_len)
-        emb = self.embedding(x)  # (batch, seq_len, embed_dim)
-        emb = emb.permute(1, 0, 2)  # (seq_len, batch, embed_dim)
-        attn_out, _ = self.attention(emb, emb, emb)
-        attn_out = attn_out.permute(1, 0, 2)  # (batch, seq_len, embed_dim)
-        x = self.ffn(attn_out)
-        pooled = x.mean(dim=1)
-        logits = self.classifier(pooled)
-        return logits
-
-
-class ClassicalTransformer(TransformerClassifier):
-    """Transformer classifier with classical components."""
-
-    def __init__(self, vocab_size: int, embedding_dim: int, num_classes: int) -> None:
-        embedding = nn.Embedding(vocab_size, embedding_dim)
-        attention = nn.MultiheadAttention(embedding_dim, num_heads=1)
-        super().__init__(embedding, attention, embedding_dim, num_classes)
+from .transformer_classifier import TransformerClassifier
+from .quantum_embedding import OptimizedQuantumEmbedding
+from .quantum_attention import HybridMultiHeadAttention
 
 
 class HybridTransformer(TransformerClassifier):

--- a/src/transformer_classifier.py
+++ b/src/transformer_classifier.py
@@ -1,0 +1,41 @@
+import torch
+import torch.nn as nn
+
+
+class TransformerClassifier(nn.Module):
+    """Simple transformer-based text classifier.
+
+    Parameters
+    ----------
+    embedding_layer : nn.Module
+        Embedding layer, either ``nn.Embedding`` or a quantum embedding.
+    attention_layer : nn.Module
+        Attention module compatible with ``nn.MultiheadAttention`` interface.
+    embedding_dim : int
+        Dimension of embeddings.
+    num_classes : int
+        Number of output classes.
+    """
+
+    def __init__(self, embedding_layer: nn.Module, attention_layer: nn.Module,
+                 embedding_dim: int, num_classes: int) -> None:
+        super().__init__()
+        self.embedding = embedding_layer
+        self.attention = attention_layer
+        self.ffn = nn.Sequential(
+            nn.Linear(embedding_dim, embedding_dim),
+            nn.ReLU(),
+            nn.Linear(embedding_dim, embedding_dim),
+        )
+        self.classifier = nn.Linear(embedding_dim, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass through the classifier."""
+        emb = self.embedding(x)  # (batch, seq_len, embed_dim)
+        emb = emb.permute(1, 0, 2)  # (seq_len, batch, embed_dim)
+        attn_out, _ = self.attention(emb, emb, emb)
+        attn_out = attn_out.permute(1, 0, 2)  # (batch, seq_len, embed_dim)
+        x = self.ffn(attn_out)
+        pooled = x.mean(dim=1)
+        logits = self.classifier(pooled)
+        return logits

--- a/train_hybrid_transformer.py
+++ b/train_hybrid_transformer.py
@@ -6,7 +6,8 @@ from sklearn.datasets import fetch_20newsgroups
 from sklearn.feature_extraction.text import CountVectorizer
 import matplotlib.pyplot as plt
 
-from src.hybrid_transformer import ClassicalTransformer, HybridTransformer
+from src.classical_transformer import ClassicalTransformer
+from src.hybrid_transformer import HybridTransformer
 
 
 class TextDataset(Dataset):


### PR DESCRIPTION
## Summary
- split hybrid and classical transformer classes into their own modules
- create reusable `TransformerClassifier` base class
- update imports in training script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418ae5b43c8332b1a54958c9a77724