### PR TITLE
Fix gradient flow in quantum embedding

### DIFF
--- a/tests/test_hybrid_transformer.py
+++ b/tests/test_hybrid_transformer.py
@@ -4,7 +4,8 @@ import torch
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from src.hybrid_transformer import ClassicalTransformer, HybridTransformer
+from src.classical_transformer import ClassicalTransformer
+from src.hybrid_transformer import HybridTransformer
 
 
 def test_classical_transformer_forward_shape():


### PR DESCRIPTION
## Summary
- keep autograd graph intact by removing `.detach()` in cache
- clear cache each forward to avoid stale graphs
- update tests for new module structure

## Testing
- `pytest -q`
- `python train_hybrid_transformer.py`

------
https://chatgpt.com/codex/tasks/task_e_6841921819a88332a4b6152eeeacd387